### PR TITLE
Update URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6+1
+
+* Update URLs in pubspec.yaml.
+
 ## 0.0.6
 
 * Fix bug in `AnimatedSampler` that caused children with non-zero offsets to

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: flutter_shaders
 description: A collection of utilities for working with the FragmentProgram API in Flutter.
-repository: https://github.com/flutter/packages/tree/main/packages/flutter_shaders
-issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_shaders%22
-version: 0.0.6
+repository: https://github.com/jonahwilliams/flutter_shaders
+issue_tracker: https://github.com/jonahwilliams/flutter_shaders/issues
+version: 0.0.6+1
 
 environment:
   sdk: '>=2.19.0-0.dev <3.0.0'


### PR DESCRIPTION
Since it doesn't appear to be part of flutter/packages (yet)?

This gets pub.dev [1] to actually link to the correct repository.

[1] https://pub.dev/packages/flutter_shaders