### PR TITLE
fix: dispose built scene for creating image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* Ensure constructed ui.Scene objects are disposed after producing ui.Image.
+
 ## 0.1.2
 
 * Ensure constructed ui.Picture objects are disposed after usage.

--- a/lib/src/animated_sampler.dart
+++ b/lib/src/animated_sampler.dart
@@ -219,17 +219,14 @@ class _ShaderSamplerBuilderLayer extends OffsetLayer {
     markNeedsAddToScene();
   }
 
-  ui.Image _buildChildScene(Rect bounds, double pixelRatio) {
+  ui.Scene _buildChildScene(double pixelRatio) {
     final ui.SceneBuilder builder = ui.SceneBuilder();
     final Matrix4 transform =
         Matrix4.diagonal3Values(pixelRatio, pixelRatio, 1);
     builder.pushTransform(transform.storage);
     addChildrenToScene(builder);
     builder.pop();
-    return builder.build().toImageSync(
-          (pixelRatio * bounds.width).ceil(),
-          (pixelRatio * bounds.height).ceil(),
-        );
+    return builder.build();
   }
 
   @override
@@ -241,15 +238,18 @@ class _ShaderSamplerBuilderLayer extends OffsetLayer {
   @override
   void addToScene(ui.SceneBuilder builder) {
     if (size.isEmpty) return;
-    final ui.Image image = _buildChildScene(
-      offset & size,
-      devicePixelRatio,
+    final bounds = Offset.zero & size;
+    final ui.Scene scene = _buildChildScene(devicePixelRatio);
+    final ui.Image image = scene.toImageSync(
+      (devicePixelRatio * bounds.width).ceil(),
+      (devicePixelRatio * bounds.height).ceil(),
     );
     final ui.PictureRecorder pictureRecorder = ui.PictureRecorder();
     final Canvas canvas = Canvas(pictureRecorder);
     try {
       callback(image, size, canvas);
     } finally {
+      scene.dispose();
       image.dispose();
     }
     final ui.Picture picture = pictureRecorder.endRecording();

--- a/lib/src/animated_sampler.dart
+++ b/lib/src/animated_sampler.dart
@@ -244,12 +244,12 @@ class _ShaderSamplerBuilderLayer extends OffsetLayer {
       (devicePixelRatio * bounds.width).ceil(),
       (devicePixelRatio * bounds.height).ceil(),
     );
+    scene.dispose();
     final ui.PictureRecorder pictureRecorder = ui.PictureRecorder();
     final Canvas canvas = Canvas(pictureRecorder);
     try {
       callback(image, size, canvas);
     } finally {
-      scene.dispose();
       image.dispose();
     }
     final ui.Picture picture = pictureRecorder.endRecording();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_shaders
 description: A collection of utilities for working with the FragmentProgram API in Flutter.
 repository: https://github.com/jonahwilliams/flutter_shaders
 issue_tracker: https://github.com/jonahwilliams/flutter_shaders/issues
-version: 0.1.2
+version: 0.1.3
 
 environment:
   sdk: '>=2.19.0 <4.0.0'


### PR DESCRIPTION
The created scene wasn't disposed in the [_buildChildScene](https://github.com/jonahwilliams/flutter_shaders/blob/be68f3470a1c2452662d80910955dccb29c89f7b/lib/src/animated_sampler.dart#L222C1-L222C62) method, so I fixed that by adding the necessary disposal logic